### PR TITLE
select:all not being triggered when expected

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -690,6 +690,10 @@ New test files in the `spec` directory are picked up automatically, no need to e
 
 ## Release notes
 
+### v1.3.1
+
+* Fixed bug when selecting all, deselecting one (or more) and selecting all again (`select:all` was not being triggered).
+
 ### v1.3.0
 
 * Fixed compatibility with Underscore 1.7.0

--- a/spec/multiSelect.selectAll.spec.js
+++ b/spec/multiSelect.selectAll.spec.js
@@ -320,6 +320,31 @@ describe( "multi-select collection: selectAll", function () {
         } );
     } );
 
+    describe( "when all models are selected, and deselecting one and reselecting all", function() {
+
+        var m1, m2, collection;
+
+        beforeEach( function () {
+            m1 = new Model();
+            m2 = new Model();
+
+            collection = new Collection( [m1, m2] );
+
+            collection.selectAll();
+            collection.deselect(m1);
+            spyOn( collection, "trigger" ).andCallThrough();
+            collection.selectAll();
+        } );
+
+        it( "should have a selected count of collection length", function () {
+            expect( collection.selectedLength ).toBe( collection.length );
+        } );
+
+        it( "should trigger a select:all event", function () {
+            expect( collection.trigger ).toHaveBeenCalledWithInitial( "select:all", { selected: [m1], deselected: [] }, collection);
+        } );
+    });
+
     describe( 'custom options', function () {
 
         describe( "when 1 model is selected, and selecting all with a custom option", function () {

--- a/src/backbone.select.js
+++ b/src/backbone.select.js
@@ -107,8 +107,8 @@
 
                     if ( !reselected.length ) {
                         this.selected[model.cid] = model;
-                        this.selectedLength = _.size( this.selected );
                     }
+                    this.selectedLength = _.size( this.selected );
                     options._processedBy[this._pickyCid] = { done: false };
 
                     if ( !options._processedBy[model.cid] ) model.select( stripLocalOptions( options ) );
@@ -149,7 +149,6 @@
 
                     this.selectedLength = 0;
                     this.each( function ( model ) {
-                        this.selectedLength++;
                         if ( this.selected[model.cid] ) reselected.push( model );
                         this.select( model, _.extend( {}, options, { _silentLocally: true } ) );
                     }, this );
@@ -175,7 +174,6 @@
                     options || (options = {});
 
                     this.each( function ( model ) {
-                        if ( model.selected ) this.selectedLength--;
                         this.deselect( model, _.extend( {}, options, { _silentLocally: true } ) );
                     }, this );
 


### PR DESCRIPTION
This PR fixes the following use case:

1. All models are selected via `selectAll()`.
1. One or more models are deselected individually.
1. All models are re-selected via `selectAll()`.

Basically, `selectedLength` sometimes would be greater than the collection's length when re-selecting certain items.

I have written a couple of unit tests to ensure the bug is fixed. If you think more unit tests should be added, let me know and I'll update the PR.

Also, I can add a commit to bump the version in `package.json` and update the `dist` directory with the result of `grunt build`.
